### PR TITLE
Feature/add absolute imports on api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -872,6 +872,8 @@
       "version": "0.8.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1120,6 +1122,8 @@
       "version": "0.3.9",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2347,22 +2351,30 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2818,6 +2830,8 @@
       "version": "8.3.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3057,7 +3071,9 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4197,7 +4213,9 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4937,6 +4955,8 @@
       "version": "4.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6297,6 +6317,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "dev": true,
@@ -6345,6 +6377,32 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/globals": {
@@ -6689,6 +6747,12 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/inquirer": {
       "version": "8.2.6",
@@ -7542,6 +7606,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -7810,7 +7883,9 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9519,6 +9594,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
@@ -11062,6 +11146,8 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11098,6 +11184,41 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-patch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.1.2.tgz",
+      "integrity": "sha512-n58F5AqjUMdp9RAKq+E1YBkmONltPVbt1nN+wrmZXoYZek6QcvaTuqvKMhYhr5BxtC53kD/exxIPA1cP1RQxsA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "global-prefix": "^3.0.0",
+        "minimist": "^1.2.8",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.4",
+        "strip-ansi": "^6.0.1"
+      },
+      "bin": {
+        "ts-patch": "bin/ts-patch.js",
+        "tspc": "bin/tspc.js"
+      }
+    },
+    "node_modules/ts-patch/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tsconfck": {
@@ -11145,6 +11266,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tsx": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.11.0.tgz",
+      "integrity": "sha512-vzGGELOgAupsNVssAmZjbUDfdm/pWP4R+Kg8TVdsonxbXk0bEpE1qh0yV6/QxUVXaVlNemgcPajGdJJ82n3stg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.20.2",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type": {
       "version": "2.7.2",
@@ -11284,6 +11424,40 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-transform-paths": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.4.7.tgz",
+      "integrity": "sha512-1Us1kdkdfKd2unbkBAOV2HHRmbRBYpSuk9nJ7cLD2hP4QmfToiM/VpxNlhJc1eezVwVqSKSBjNSzZsK/fWR/9A==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "peerDependencies": {
+        "typescript": ">=3.6.5"
+      }
+    },
+    "node_modules/typescript-transform-paths/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/typescript-transform-paths/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {
@@ -11469,7 +11643,9 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -11957,6 +12133,8 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12031,8 +12209,10 @@
         "@types/morgan": "1.9.9",
         "nodemon": "3.1.0",
         "rimraf": "5.0.5",
-        "ts-node": "10.9.2",
-        "typescript": "5.4.4"
+        "ts-patch": "^3.1.2",
+        "tsx": "^4.11.0",
+        "typescript": "5.4.4",
+        "typescript-transform-paths": "^3.4.7"
       }
     },
     "packages/api/node_modules/glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,11 +2779,6 @@
         "es5-ext": "^0.10.47"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -6701,11 +6696,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -8265,83 +8255,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/nodemon": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -9199,11 +9112,6 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
       "dev": true,
       "license": "MIT"
     },
@@ -10323,17 +10231,6 @@
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "dev": true,
@@ -11062,17 +10959,6 @@
         }
       ]
     },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -11507,11 +11393,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -12207,7 +12088,6 @@
         "@types/cors": "2.8.17",
         "@types/express": "4.17.21",
         "@types/morgan": "1.9.9",
-        "nodemon": "3.1.0",
         "rimraf": "5.0.5",
         "ts-patch": "^3.1.2",
         "tsx": "^4.11.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,6 @@
     "@types/cors": "2.8.17",
     "@types/express": "4.17.21",
     "@types/morgan": "1.9.9",
-    "nodemon": "3.1.0",
     "rimraf": "5.0.5",
     "ts-patch": "^3.1.2",
     "tsx": "^4.11.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "main": "dist/app.js",
   "scripts": {
-    "build": "rimraf dist && tsc",
-    "dev": "nodemon src/app.ts",
+    "build": "rimraf dist && tspc",
+    "dev": "tsx watch src/app.ts",
     "start": "node dist/app.js"
   },
   "keywords": [],
@@ -17,8 +17,10 @@
     "@types/morgan": "1.9.9",
     "nodemon": "3.1.0",
     "rimraf": "5.0.5",
-    "ts-node": "10.9.2",
-    "typescript": "5.4.4"
+    "ts-patch": "^3.1.2",
+    "tsx": "^4.11.0",
+    "typescript": "5.4.4",
+    "typescript-transform-paths": "^3.4.7"
   },
   "dependencies": {
     "cors": "2.8.5",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,13 +1,13 @@
-import express from "express";
 import cors from "cors";
+import express from "express";
 import helmet from "helmet";
 import morgan from "morgan";
 
 import serverless from "serverless-http";
 
-import routes from "./routes/index.js";
-import middlewares from "./middlewares.js";
-import envParsed from "./envParsed.js";
+import envParsed from "@/envParsed.js";
+import middlewares from "@/middlewares/index.js";
+import routes from "@/routes/index.js";
 
 const app = express();
 

--- a/packages/api/src/middlewares/errors.ts
+++ b/packages/api/src/middlewares/errors.ts
@@ -1,5 +1,5 @@
+import envParsed from "@/envParsed.js";
 import { Request, Response, NextFunction } from "express";
-import envParsed from "./envParsed.js";
 
 export const STATUS_CODES = {
   NOT_FOUND: 404,
@@ -19,24 +19,11 @@ function notFound(req: Request, res: Response, next: NextFunction) {
 function errorHandler(err: unknown, req: Request, res: Response) {
   console.error(err);
 
-  const statusCode =
-    res.statusCode !== 200
-      ? res.statusCode
-      : STATUS_CODES.INTERNAL_SERVER_ERROR;
+  const statusCode = res.statusCode !== 200 ? res.statusCode : STATUS_CODES.INTERNAL_SERVER_ERROR;
 
-  const message =
-    err &&
-    (err instanceof Error || (typeof err === "object" && "message" in err))
-      ? err.message
-      : "Internal Server Error";
+  const message = err && (err instanceof Error || (typeof err === "object" && "message" in err)) ? err.message : "Internal Server Error";
 
-  const stack =
-    envParsed().NODE_ENV === "development" &&
-    err &&
-    typeof err === "object" &&
-    "stack" in err
-      ? err.stack
-      : undefined;
+  const stack = envParsed().NODE_ENV === "development" && err && typeof err === "object" && "stack" in err ? err.stack : undefined;
 
   res.status(statusCode);
   res.json({

--- a/packages/api/src/middlewares/index.ts
+++ b/packages/api/src/middlewares/index.ts
@@ -1,0 +1,7 @@
+import errorMiddleware from "./errors.js";
+
+const middlewares = {
+  ...errorMiddleware,
+};
+
+export default middlewares;

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -7,10 +7,12 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "./dist"
-  },
-  "ts-node": {
-    "esm": true
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "plugins": [{ "transform": "typescript-transform-paths" }]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This add absolute path import with @ as a prefix.
Solves the second half of https://github.com/chescalante/react-monorepo-template/issues/5.

## Changes

### Remove nodemon and `ts-node` as devDependencies in favor of `tsx`
With `tsx` you can simply run a ts project without any config or extra packages needed. [Repo link](https://github.com/privatenumber/tsx). Here is a [comparison with other ts-runtimes](https://github.com/privatenumber/ts-runtime-comparison).
This change is made because I was having problems to run path aliases with `nodemon` + `ts-node` and tsx worked out of the box.
The philosophy behind `tsx` is that it runs ts without checking types, because it relies on IDE integrations to tell you if you have any errors (red squiggly lines). So some kind of precommit or maybe CI pipe for typechecking would be nice.

### Usage of `ts-patch`s `tspc` CLI command to build the project instead of plain `tsc`
This is because when you use path aliases to develop you project typescript doesn't know how to resolve that, so any build will include absolute imports and therefore fail to run. To solve this issue, we need to "patch" the typescript installation to allow the usage of plugins (this is where `ts-patch` comes to play), in this case `typescript-transform-paths` ([repo link](https://github.com/LeDDGroup/typescript-transform-paths)). What this package does is transform back the absolute imports to relative ones at build time.
